### PR TITLE
Add support for KEYCLOAK_DATABASE_SCHEMA

### DIFF
--- a/12/debian-10/rootfs/opt/bitnami/scripts/keycloak-env.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/keycloak-env.sh
@@ -51,6 +51,7 @@ keycloak_env_vars=(
     KEYCLOAK_DATABASE_USER
     KEYCLOAK_DATABASE_NAME
     KEYCLOAK_DATABASE_PASSWORD
+    KEYCLOAK_DATABASE_SCHEMA
     KEYCLOAK_DAEMON_USER
     KEYCLOAK_DAEMON_GROUP
     KEYCLOAK_USER
@@ -66,6 +67,7 @@ keycloak_env_vars=(
     DB_USER
     DB_DATABASE
     DB_PASSWORD
+    DB_SCHEMA
 )
 for env_var in "${keycloak_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -143,6 +145,10 @@ KEYCLOAK_DATABASE_NAME="${KEYCLOAK_DATABASE_NAME:-"${DB_DATABASE:-}"}"
 export KEYCLOAK_DATABASE_NAME="${KEYCLOAK_DATABASE_NAME:-bitnami_keycloak}"
 KEYCLOAK_DATABASE_PASSWORD="${KEYCLOAK_DATABASE_PASSWORD:-"${DB_PASSWORD:-}"}"
 export KEYCLOAK_DATABASE_PASSWORD="${KEYCLOAK_DATABASE_PASSWORD:-}"
+KEYCLOAK_DATABASE_SCHEMA="${KEYCLOAK_DATABASE_SCHEMA:-"${DB_SCHEMA:-}"}"
+# if this image is ever designed to support mariadb/mysql in addition to postgres, the default
+# schema name should be dbo for those databases
+export KEYCLOAK_DATABASE_SCHEMA="${KEYCLOAK_DATABASE_SCHEMA:-public}"
 
 # System users (when running with a privileged user)
 export KEYCLOAK_DAEMON_USER="${KEYCLOAK_DAEMON_USER:-keycloak}"

--- a/12/debian-10/rootfs/opt/bitnami/scripts/keycloak-env.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/keycloak-env.sh
@@ -146,8 +146,6 @@ export KEYCLOAK_DATABASE_NAME="${KEYCLOAK_DATABASE_NAME:-bitnami_keycloak}"
 KEYCLOAK_DATABASE_PASSWORD="${KEYCLOAK_DATABASE_PASSWORD:-"${DB_PASSWORD:-}"}"
 export KEYCLOAK_DATABASE_PASSWORD="${KEYCLOAK_DATABASE_PASSWORD:-}"
 KEYCLOAK_DATABASE_SCHEMA="${KEYCLOAK_DATABASE_SCHEMA:-"${DB_SCHEMA:-}"}"
-# if this image is ever designed to support mariadb/mysql in addition to postgres, the default
-# schema name should be dbo for those databases
 export KEYCLOAK_DATABASE_SCHEMA="${KEYCLOAK_DATABASE_SCHEMA:-public}"
 
 # System users (when running with a privileged user)

--- a/12/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/12/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -102,7 +102,7 @@ batch
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation-millis, value=60000)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=flush-strategy, value=IdleConnections)
 /subsystem=datasources/jdbc-driver=postgresql:add(driver-name=postgresql, driver-module-name=org.postgresql.jdbc, driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
-/subsystem=keycloak-server/spi=connectionsJpa/provider=default:write-attribute(name=properties.schema,value=public)
+/subsystem=keycloak-server/spi=connectionsJpa/provider=default:write-attribute(name=properties.schema,value=${KEYCLOAK_DATABASE_SCHEMA})
 run-batch
 stop-embedded-server
 EOF

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The Bitnami Keycloak container requires a PostgreSQL database to work. This is c
 - `KEYCLOAK_DATABASE_NAME`: PostgreSQL database name. Default : **bitnami_keycloak**.
 - `KEYCLOAK_DATABASE_USER`: PostgreSQL database user. Default : **bn_keycloak**.
 - `KEYCLOAK_DATABASE_PASSWORD`: PostgreSQL database password. No defaults.
+- `KEYCLOAK_DATABASE_SCHEMA`: PostgreSQL database schema. Default : **public**.
 
 ## Port and address binding
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ The Bitnami Keycloak container requires a PostgreSQL database to work. This is c
 
 - `KEYCLOAK_DATABASE_HOST`: PostgreSQL host. Default: **postgresql**.
 - `KEYCLOAK_DATABASE_PORT`: PostgreSQL port. Default: **5432**.
-- `KEYCLOAK_DATABASE_NAME`: PostgreSQL database name. Default : **bitnami_keycloak**.
-- `KEYCLOAK_DATABASE_USER`: PostgreSQL database user. Default : **bn_keycloak**.
+- `KEYCLOAK_DATABASE_NAME`: PostgreSQL database name. Default: **bitnami_keycloak**.
+- `KEYCLOAK_DATABASE_USER`: PostgreSQL database user. Default: **bn_keycloak**.
 - `KEYCLOAK_DATABASE_PASSWORD`: PostgreSQL database password. No defaults.
-- `KEYCLOAK_DATABASE_SCHEMA`: PostgreSQL database schema. Default : **public**.
+- `KEYCLOAK_DATABASE_SCHEMA`: PostgreSQL database schema. Default: **public**.
 
 ## Port and address binding
 


### PR DESCRIPTION
Fixes https://github.com/bitnami/charts/issues/5626

**Description of the change**

Modifies jboss's idiosyncratic Wildfly configuration script to specify the postgres schema used for the keycloak migration from an environment variable `KEYCLOAK_DATABASE_SCHEMA` that defaults to `public`.

Adds the environment variable to a bitnami script.

**Benefits**

Makes the image more compatible with the upstream keycloak image, which supports specifying the schema.

**Possible drawbacks**

If you ever support MySql/MariaDb like upstream does, you'll want the default to be `dbo` instead of `public`.

**Applicable issues**

https://github.com/bitnami/charts/issues/5626