### PR TITLE
bugfix: keycloak database password contains special characters

### DIFF
--- a/13/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/13/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -96,7 +96,7 @@ embed-server --server-config=${KEYCLOAK_CONF_FILE} --std-out=echo
 batch
 /subsystem=datasources/data-source=KeycloakDS: remove()
 /subsystem=datasources/data-source=KeycloakDS: add(jndi-name=java:jboss/datasources/KeycloakDS,enabled=true,use-java-context=true,use-ccm=true, connection-url=jdbc:postgresql://${KEYCLOAK_DATABASE_HOST}:${KEYCLOAK_DATABASE_PORT}/${KEYCLOAK_DATABASE_NAME}, driver-name=postgresql)
-/subsystem=datasources/data-source=KeycloakDS: write-attribute(name=user-name, value=${KEYCLOAK_DATABASE_USER})
+/subsystem=datasources/data-source=KeycloakDS: write-attribute(name=user-name, value=\${env.KEYCLOAK_DATABASE_USER})
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=check-valid-connection-sql, value="SELECT 1")
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation, value=true)
 /subsystem=datasources/data-source=KeycloakDS: write-attribute(name=background-validation-millis, value=60000)
@@ -111,7 +111,7 @@ EOF
         debug_execute jboss-cli.sh <<EOF
 embed-server --server-config=${KEYCLOAK_CONF_FILE} --std-out=echo
 batch
-/subsystem=datasources/data-source=KeycloakDS: write-attribute(name=password, value=${KEYCLOAK_DATABASE_PASSWORD})
+/subsystem=datasources/data-source=KeycloakDS: write-attribute(name=password, value=\${env.KEYCLOAK_DATABASE_PASSWORD})
 run-batch
 stop-embedded-server
 EOF


### PR DESCRIPTION
**Description of the change**
Hello guys.

When I upgrade my KeyCloak from `jboss/keycloak:11.0.0` to `docker.io/bitnami/keycloak:13.0.1`, I got the following errors:
![Screenshot from 2021-06-16 23-49-03](https://user-images.githubusercontent.com/6848311/122260459-821e3e80-cefd-11eb-9d9d-216e3f75ee42.png)
The stack trace is very looooong and un-clearly. After two weeks of debugging, I finally find out the root cause:
![Screenshot from 2021-06-16 22-50-04](https://user-images.githubusercontent.com/6848311/122260657-b8f45480-cefd-11eb-874e-53c49e5afeea.png)
This is because my `KEYCLOAK_DATABASE_PASSWORD` is auto-generated and it contains some special characters (especially `/`). 
Then in the startup script, what `libkeycloak.sh` doing is put **raw text** into `KEYCLOAK_CONF_FILE` instead of ref `env.KEYCLOAK_DATABASE_PASSWORD`

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
