### PR TITLE
Fix invalid chart reference in README (was: Thanos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ docker run --name keycloak bitnami/keycloak:latest
 
 # How to deploy Keycloak in Kubernetes?
 
-Deploying Bitnami applications as Helm Charts is the easiest way to get started with our applications on Kubernetes. Read more about the installation in the [Bitnami Thanos Chart GitHub repository](https://github.com/bitnami/charts/tree/master/bitnami/keycloak).
+Deploying Bitnami applications as Helm Charts is the easiest way to get started with our applications on Kubernetes. Read more about the installation in the [Bitnami Keycloak Chart GitHub repository](https://github.com/bitnami/charts/tree/master/bitnami/keycloak).
 
 # Why use a non-root container?
 


### PR DESCRIPTION
**Description of the change**

Found a word error in the README. The chart reference talks about the [Thanos chart repository](https://github.com/bitnami/charts/tree/master/bitnami/thanos).

**Benefits**

Documentation correctness.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

None.

<hr>

Thank you for maintaining these public images.
