### PR TITLE
Feature/tls based on proxy settings

### DIFF
--- a/17/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/17/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -41,8 +41,14 @@ keycloak_validate() {
         fi
     }
     if is_boolean_yes "$KEYCLOAK_PRODUCTION"; then
-        if ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
-            print_validation_error "You need to have the TLS enable. Please set the KEYCLOAK_ENABLE_TLS variable to true"
+        if [[ "${KEYCLOAK_PROXY}" == "edge" ]]; then
+            # https://www.keycloak.org/server/reverseproxy
+            if is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
+                print_validation_error "TLS and proxy=edge are not compatible. Please set the KEYCLOAK_ENABLE_TLS variable to false when using KEYCLOAK_PROXY=edge. Review # https://www.keycloak.org/server/reverseproxy for more information about proxy settings."
+            fi
+        else ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"
+            # keycloak proxy passthrough/reencrypt requires tls
+            print_validation_error "You need to have TLS enabled. Please set the KEYCLOAK_ENABLE_TLS variable to true"
         fi
     fi
 
@@ -150,7 +156,7 @@ keycloak_configure_metrics() {
 }
 
 ########################
-# Configure hostname 
+# Configure hostname
 # Globals:
 #   KEYCLOAK_*
 # Arguments:
@@ -164,7 +170,7 @@ keycloak_configure_hostname(){
 }
 
 ########################
-# Configure http 
+# Configure http
 # Globals:
 #   KEYCLOAK_*
 # Arguments:

--- a/18/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/18/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -41,8 +41,14 @@ keycloak_validate() {
         fi
     }
     if is_boolean_yes "$KEYCLOAK_PRODUCTION"; then
-        if ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
-            print_validation_error "You need to have the TLS enable. Please set the KEYCLOAK_ENABLE_TLS variable to true"
+        if [[ "${KEYCLOAK_PROXY}" == "edge" ]]; then
+            # https://www.keycloak.org/server/reverseproxy
+            if is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
+                print_validation_error "TLS and proxy=edge are not compatible. Please set the KEYCLOAK_ENABLE_TLS variable to false when using KEYCLOAK_PROXY=edge. Review # https://www.keycloak.org/server/reverseproxy for more information about proxy settings."
+            fi
+        else ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"
+            # keycloak proxy passthrough/reencrypt requires tls
+            print_validation_error "You need to have TLS enabled. Please set the KEYCLOAK_ENABLE_TLS variable to true"
         fi
     fi
 
@@ -150,7 +156,7 @@ keycloak_configure_metrics() {
 }
 
 ########################
-# Configure hostname 
+# Configure hostname
 # Globals:
 #   KEYCLOAK_*
 # Arguments:
@@ -164,7 +170,7 @@ keycloak_configure_hostname(){
 }
 
 ########################
-# Configure http 
+# Configure http
 # Globals:
 #   KEYCLOAK_*
 # Arguments:

--- a/README.md
+++ b/README.md
@@ -213,8 +213,7 @@ Keycloak's branch 17 is no longer maintained by upstream and is now internally t
 
 ### 17-debian-10
 
-Keycloak 17 is powered by Quarkus and to deploy it in production mode it is necessary to set up TLS.
-To do this you need to set `KEYCLOAK_PRODUCTION` to **true** and configure TLS
+Keycloak 17 is powered by Quarkus, and quite a things have changed. Most notably, `KEYCLOAK_PRODUCTION` should be set to **true** and `KEYCLOAK_PROXY` mode should be configured taking into account the information from [keycloak](https://www.keycloak.org/server/reverseproxy). If using anything other than `edge`, you must configure TLS.
 
 ## Contributing
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Ensure that the `tls` settings are required if the proxy is set to anything other than `edge`. In edge mode, no TLS settings should be passed (hence the check to see if TLS is enabled when proxy=edge).

This ensures that `edge` and `passthrough`/`reencrypt` modes of running keycloak are satisfied whilst also still allowing for `KEYCLOAK_PRODUCTION` to be set to start keycloak with `start` vs `start-dev`

**Benefits**

Ensure `proxy=edge` is taken into consideration, as currently `passthrough` and `reencrypt` are the only options "out of the box" when using this within the keycloak helm chart

**Possible drawbacks**

None, this doesn't change any of the original behaviour

**Applicable issues**

fixes: https://github.com/bitnami/bitnami-docker-keycloak/issues/60
relates_to: https://github.com/bitnami/charts/issues/10236

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
