### PR TITLE
Fix check of KEYCLOAK_ENABLE_TLS env var in entrypoint

### DIFF
--- a/17/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/17/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -46,8 +46,7 @@ keycloak_validate() {
             if is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
                 print_validation_error "TLS and proxy=edge are not compatible. Please set the KEYCLOAK_ENABLE_TLS variable to false when using KEYCLOAK_PROXY=edge. Review # https://www.keycloak.org/server/reverseproxy for more information about proxy settings."
             fi
-        else
-            ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"
+        elif ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
             # keycloak proxy passthrough/reencrypt requires tls
             print_validation_error "You need to have TLS enabled. Please set the KEYCLOAK_ENABLE_TLS variable to true"
         fi

--- a/17/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/17/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -46,8 +46,7 @@ keycloak_validate() {
             if is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
                 print_validation_error "TLS and proxy=edge are not compatible. Please set the KEYCLOAK_ENABLE_TLS variable to false when using KEYCLOAK_PROXY=edge. Review # https://www.keycloak.org/server/reverseproxy for more information about proxy settings."
             fi
-        else
-            ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"
+        elif ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
             # keycloak proxy passthrough/reencrypt requires tls
             print_validation_error "You need to have TLS enabled. Please set the KEYCLOAK_ENABLE_TLS variable to true"
         fi

--- a/18/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/18/debian-10/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -46,8 +46,7 @@ keycloak_validate() {
             if is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
                 print_validation_error "TLS and proxy=edge are not compatible. Please set the KEYCLOAK_ENABLE_TLS variable to false when using KEYCLOAK_PROXY=edge. Review # https://www.keycloak.org/server/reverseproxy for more information about proxy settings."
             fi
-        else
-            ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"
+        elif ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
             # keycloak proxy passthrough/reencrypt requires tls
             print_validation_error "You need to have TLS enabled. Please set the KEYCLOAK_ENABLE_TLS variable to true"
         fi

--- a/18/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/18/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -46,8 +46,7 @@ keycloak_validate() {
             if is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
                 print_validation_error "TLS and proxy=edge are not compatible. Please set the KEYCLOAK_ENABLE_TLS variable to false when using KEYCLOAK_PROXY=edge. Review # https://www.keycloak.org/server/reverseproxy for more information about proxy settings."
             fi
-        else
-            ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"
+        elif ! is_boolean_yes "$KEYCLOAK_ENABLE_TLS"; then
             # keycloak proxy passthrough/reencrypt requires tls
             print_validation_error "You need to have TLS enabled. Please set the KEYCLOAK_ENABLE_TLS variable to true"
         fi


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The commit https://github.com/bitnami/bitnami-docker-keycloak/pull/68/commits/bce94bbf0c40e065c6fd8d6e46d5b8849358c233 introduced a regression in the docker container entrypoint, making the container fail to start when $KEYCLOAK_PRODUCTION is set to 'true' (no matter the value of $KEYCLOAK_ENABLE_TLS).

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
