### PR TITLE
Change group ownership of /opt/bitnami/keycloak to GID 0 (#78)

### DIFF
--- a/18/debian-11/Dockerfile
+++ b/18/debian-11/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 
+ARG KEYCLOAK_DAEMON_GROUP=0
+
 COPY rootfs /
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/keycloak/postunpack.sh


### PR DESCRIPTION
The application makes changes in `/opt/bitnami/keycloak`, and some Kubernetes environments (namely Openshift) run containers by default with an ephemeral UID and GID 0.

Signed-off-by: Burt Holzman <burt@fnal.gov>

**Description of the change**

Changes ownership of /opt/bitnami/keycloak to GID 0

**Benefits**

Allows running application in Openshift

**Possible drawbacks**

None

**Applicable issues**

- Fixes #78