### PR TITLE
added --auto-build param to start command

### DIFF
--- a/18/debian-11/rootfs/opt/bitnami/scripts/keycloak-env.sh
+++ b/18/debian-11/rootfs/opt/bitnami/scripts/keycloak-env.sh
@@ -63,6 +63,7 @@ keycloak_env_vars=(
     DB_PASSWORD
     DB_SCHEMA
     JDBC_PARAMS
+    AUTO_BUILD
 )
 for env_var in "${keycloak_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -137,5 +138,5 @@ export KEYCLOAK_JDBC_PARAMS="${KEYCLOAK_JDBC_PARAMS:-}"
 # System users (when running with a privileged user)
 export KEYCLOAK_DAEMON_USER="${KEYCLOAK_DAEMON_USER:-keycloak}"
 export KEYCLOAK_DAEMON_GROUP="${KEYCLOAK_DAEMON_GROUP:-keycloak}"
-
 # Custom environment variables may be defined below
+export AUTO_BUILD="${AUTO_BUILD:-false}"

--- a/18/debian-11/rootfs/opt/bitnami/scripts/keycloak/run.sh
+++ b/18/debian-11/rootfs/opt/bitnami/scripts/keycloak/run.sh
@@ -19,9 +19,12 @@ info "** Starting keycloak **"
 # Use only basename
 conf_file="${KEYCLOAK_CONF_DIR}/${KEYCLOAK_CONF_FILE}"
 
-is_boolean_yes "$KEYCLOAK_PRODUCTION" && start_param="start --auto-build" || start_param="start-dev"
+is_boolean_yes "$KEYCLOAK_PRODUCTION" && start_param="start" || start_param="start-dev"
 
 start_command=("${KEYCLOAK_BIN_DIR}/kc.sh" "-cf" "$conf_file" "$start_param")
+
+# Run keycloak server with auto-build parameter
+is_boolean_yes "$AUTO_BUILD" && start_command+=("--auto-build")
 
 # Add extra args
 if [[ -n "$KEYCLOAK_EXTRA_ARGS" ]]; then

--- a/18/debian-11/rootfs/opt/bitnami/scripts/keycloak/run.sh
+++ b/18/debian-11/rootfs/opt/bitnami/scripts/keycloak/run.sh
@@ -19,7 +19,7 @@ info "** Starting keycloak **"
 # Use only basename
 conf_file="${KEYCLOAK_CONF_DIR}/${KEYCLOAK_CONF_FILE}"
 
-is_boolean_yes "$KEYCLOAK_PRODUCTION" && start_param="start" || start_param="start-dev"
+is_boolean_yes "$KEYCLOAK_PRODUCTION" && start_param="start --auto-build" || start_param="start-dev"
 
 start_command=("${KEYCLOAK_BIN_DIR}/kc.sh" "-cf" "$conf_file" "$start_param")
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ volumes:
 
 The Bitnami Keycloak container can activate different set of statistics (database, jgroups and http) by setting the environment variable `KEYCLOAK_ENABLE_STATISTICS=true`.
 
+### Running Keycloak with auto-build
+
+In case you want to trigger build on each config change use following environment variable:
+
+- `AUTO_BUILD`: Enable auto-build when running `kc.sh`. Default: **false**.
+
 #### Full configuration
 
 The image looks for configuration files in the `/bitnami/keycloak/configuration/` directory, this directory can be changed by setting the KEYCLOAK_MOUNTED_CONF_DIR environment variable.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->
After changes from https://github.com/bitnami/bitnami-docker-keycloak/commit/920085ca2eea6aa90c9e21c1f86d1c89aae01952 there is no `kc.sh build` command run during entrypoint execution. As a result, any necessary changes made to config `/opt/bitnami/keycloak/conf/keycloak.conf` meant for a build step are conflicting with defaults, resulting in errors.

**Description of the change**
Addition of `--auto-build` flag to the `start_param` variable in `/opt/bitnami/scripts/keycloak/run.sh` script.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Everytime a change to parameters is detected by the keycloak server a build will be triggered before running keycloak start command.
https://www.keycloak.org/server/configuration#_the_auto_build_option_automatic_detection_when_the_server_needs_a_build
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
Slightly longer execution time.
<!-- Describe any known limitations with your change -->

**Applicable issues**
https://github.com/bitnami/charts/issues/11067

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**
As of now a helm chart running the image cannot be used in production mode for 18.0.2-debian-11-r1 and newer release.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
